### PR TITLE
Fix compilation on Android with nCine

### DIFF
--- a/framework_c++/jugimapNCINE/jmNCine.h
+++ b/framework_c++/jugimapNCINE/jmNCine.h
@@ -48,6 +48,7 @@ public:
     int Pos() override {return ncIFile->tell();}
     void Seek(int _pos) override {ncIFile->seek(_pos, SEEK_SET);}
     int Size() override {return ncIFile->size();}
+    void Close() override {ncIFile->close();}
 
 
     unsigned char ReadByte()  override


### PR DESCRIPTION
I have fixed the compilation on Android by adding an implementation for the `Close()` method in the `AndroidBinaryFileStreamReaderNC` class.