### PR TITLE
Update prefix of default data compiler definition

### DIFF
--- a/examples_c++/FrameworkDemo/FrameworkDemo_nCine/main.cpp
+++ b/examples_c++/FrameworkDemo/FrameworkDemo_nCine/main.cpp
@@ -31,8 +31,8 @@ void MyEventHandler::onPreInit(ncine::AppConfiguration &config)
 #elif defined(__EMSCRIPTEN__)
     config.dataPath() = "/";
 #else
-    #ifdef PACKAGE_DEFAULT_DATA_DIR
-    config.dataPath() = PACKAGE_DEFAULT_DATA_DIR;
+    #ifdef NCPROJECT_DEFAULT_DATA_DIR
+    config.dataPath() = NCPROJECT_DEFAULT_DATA_DIR;
     #else
     config.dataPath() = "data/";
     #endif

--- a/examples_c++/GuiDemo/GuiDemo_nCine/main.cpp
+++ b/examples_c++/GuiDemo/GuiDemo_nCine/main.cpp
@@ -33,8 +33,8 @@ void MyEventHandler::onPreInit(ncine::AppConfiguration &config)
 #elif defined(__EMSCRIPTEN__)
     config.dataPath() = "/";
 #else
-    #ifdef PACKAGE_DEFAULT_DATA_DIR
-    config.dataPath() = PACKAGE_DEFAULT_DATA_DIR;
+    #ifdef NCPROJECT_DEFAULT_DATA_DIR
+    config.dataPath() = NCPROJECT_DEFAULT_DATA_DIR;
     #else
     config.dataPath() = "data/";
     #endif

--- a/examples_c++/GuiDemo/GuiDemo_nCine/main.cpp
+++ b/examples_c++/GuiDemo/GuiDemo_nCine/main.cpp
@@ -3,6 +3,7 @@
 #include <ncine/IFile.h>
 #include <ncine/FileSystem.h>
 #include <ncine/Keys.h>
+#include <ncine/Viewport.h>
 
 #include "jugiApp/app.h"
 
@@ -60,7 +61,7 @@ void MyEventHandler::onInit()
 
     ncine::theApplication().setAutoSuspension(true);
 
-     ncine::theApplication().gfxDevice().setClearColor (0.13333, 0.13333, 0.13333, 1.0);
+     ncine::theApplication().rootViewport().setClearColor (0.13333, 0.13333, 0.13333, 1.0);
 
     // JUGIMAP CORE INITIALIZATION
     //---------------------------------------------------

--- a/examples_c++/ParallaxScrolling/ParallaxScrolling_nCine/main.cpp
+++ b/examples_c++/ParallaxScrolling/ParallaxScrolling_nCine/main.cpp
@@ -31,8 +31,8 @@ void MyEventHandler::onPreInit(ncine::AppConfiguration &config)
 #elif defined(__EMSCRIPTEN__)
     config.dataPath() = "/";
 #else
-    #ifdef PACKAGE_DEFAULT_DATA_DIR
-    config.dataPath() = PACKAGE_DEFAULT_DATA_DIR;
+    #ifdef NCPROJECT_DEFAULT_DATA_DIR
+    config.dataPath() = NCPROJECT_DEFAULT_DATA_DIR;
     #else
     config.dataPath() = "data/";
     #endif

--- a/examples_c++/SpriteTimelineAnimation/SpriteTimelineAnimation_nCine/main.cpp
+++ b/examples_c++/SpriteTimelineAnimation/SpriteTimelineAnimation_nCine/main.cpp
@@ -31,8 +31,8 @@ void MyEventHandler::onPreInit(ncine::AppConfiguration &config)
 #elif defined(__EMSCRIPTEN__)
     config.dataPath() = "/";
 #else
-    #ifdef PACKAGE_DEFAULT_DATA_DIR
-    config.dataPath() = PACKAGE_DEFAULT_DATA_DIR;
+    #ifdef NCPROJECT_DEFAULT_DATA_DIR
+    config.dataPath() = NCPROJECT_DEFAULT_DATA_DIR;
     #else
     config.dataPath() = "data/";
     #endif

--- a/framework_c++/jugimap/jmGlobal.cpp
+++ b/framework_c++/jugimap/jmGlobal.cpp
@@ -52,6 +52,7 @@ Vec2f GetRelativeHandleFromTextHandleVariant(TextHandleVariant _thv)
 
     switch (_thv)
     {
+    default:
     case TextHandleVariant::CENTER:
         return Vec2f(0.5f, 0.5f);
 

--- a/framework_c++/jugimapNCINE/jmNCine.h
+++ b/framework_c++/jugimapNCINE/jmNCine.h
@@ -7,6 +7,8 @@
 #define JUGIMAP_NCINE_H
 
 #include <ncine/imgui.h>
+#include <ncine/Camera.h>
+#include <ncine/Viewport.h>
 #include <ncine/Texture.h>
 #include <ncine/Sprite.h>
 #include <ncine/DrawableNode.h>
@@ -319,6 +321,8 @@ public:
 
 private:
     MapNCNode * mMapNCNode = nullptr;                       // LINK
+    ncine::Viewport mViewport;
+    ncine::Camera mCamera;
 };
 
 


### PR DESCRIPTION
- Fix a compiler warning in `jmGlobal.cpp`

This change add support for the new template project scripts that are now integrated inside the engine.